### PR TITLE
Fixed normalizing address data with NULL values

### DIFF
--- a/src/Normalizer/FromJson/AddressNormalizer.php
+++ b/src/Normalizer/FromJson/AddressNormalizer.php
@@ -22,11 +22,11 @@ final class AddressNormalizer
     public function normalize(object $jsonData): Address
     {
         return new Address(
-            $jsonData->Thoroughfarename,
+            $jsonData->Thoroughfarename ?? '',
             $jsonData->Housenumber ?? '',
             new Municipality(
-                $jsonData->Zipcode,
-                $jsonData->Municipality
+                $jsonData->Zipcode ?? '',
+                $jsonData->Municipality ?? ''
             )
         );
     }

--- a/tests/Normalizer/FromJson/AddressNormalizerTest.php
+++ b/tests/Normalizer/FromJson/AddressNormalizerTest.php
@@ -29,15 +29,15 @@ class AddressNormalizerTest extends TestCase
 EOT;
 
     /**
-     * Json data to test where house number is empty.
+     * Json data to test where values are empty.
      *
      * @var string
      */
     private $jsonWithoutHouseNumber = <<<EOT
 {
-    "Municipality": "Zonhoven",
-    "Zipcode": "3120",
-    "Thoroughfarename": "Trambergstraat",
+    "Municipality": null,
+    "Zipcode": null,
+    "Thoroughfarename": null,
     "Housenumber": null
 }
 EOT;
@@ -72,9 +72,9 @@ EOT;
     public function jsonDataWithoutHouseNumberCanBeNormalized(): void
     {
         $expected = new Address(
-            'Trambergstraat',
             '',
-            new Municipality('3120', 'Zonhoven')
+            '',
+            new Municipality('', '')
         );
 
         $normalizer = new AddressNormalizer();


### PR DESCRIPTION
When a search returns a partial address (eg search by municipality name)
some fields will be empty in the returned data. Address & Municipality
value objects the values to be a string.